### PR TITLE
Match release executable name to install commands

### DIFF
--- a/docs/infrastructure/fleet-on-centos.md
+++ b/docs/infrastructure/fleet-on-centos.md
@@ -23,7 +23,7 @@ To install Fleet, run the following:
 ```
 $ wget https://dl.kolide.co/bin/fleet_latest.zip
 $ unzip fleet_latest.zip 'linux/*' -d fleet
-$ sudo cp fleet/linux/fleet /usr/bin/fleet
+$ sudo cp fleet/linux/fleet* /usr/bin/fleet
 ```
 
 ## Installing and configuring dependencies


### PR DESCRIPTION
Current fleet_latest.zip linux executable name is fleet_linux_amd64, which doesn't match sudo cp